### PR TITLE
Fix VSCode JUnit TestRunner invocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,17 @@
       <version>${jettyVersion}</version>
     </dependency>
 
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+    </dependency>
+
  </dependencies>
 
 <build>
+    <testSourceDirectory>${project.basedir}/test/unit/test</testSourceDirectory>
     <plugins>
         <plugin>
             <groupId>org.eclipse.jetty</groupId>

--- a/test/unit/test/CalculatorTest.java
+++ b/test/unit/test/CalculatorTest.java
@@ -1,0 +1,42 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+import uts.isd.model.Calculator;
+
+public class CalculatorTest {
+
+    private Calculator calculator;
+
+    public CalculatorTest() {
+        calculator = new Calculator();
+    }
+
+    @Test
+    public void evaluatesExpression() {
+        int sum = calculator.evaluate("1+2+3");
+        assertEquals(6, sum);
+    }
+
+    @Test
+    public void testAdd() {
+        int res = calculator.add(2, 5);
+        assertEquals(7, res);
+    }
+
+    @Test
+    public void testSub() {
+        int res = calculator.subtract(5, 3);
+        assertEquals(2, res);
+    }
+
+    @Test
+    public void testMul() {
+        int res = calculator.mul(2, 4);
+        assertEquals(8, res);
+    }
+
+    @Test
+    public void testPow() {
+        double res = calculator.power(2, 3);
+        assertEquals(8.00, res, 0.001);
+    }
+}

--- a/test/unit/test/TestRunner.java
+++ b/test/unit/test/TestRunner.java
@@ -1,10 +1,20 @@
-package unit.test;
-
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 public class TestRunner {
     public static void main(String[] args) {
+        System.out.println("- Testing Calculator: ");
+        Result result = JUnitCore.runClasses(CalculatorTest.class);
+        for (Failure failure : result.getFailures()) {
+            System.out.println(failure.toString());
+        }
+
+        String status = result.wasSuccessful() ? "Passed" : "Failed";
+        System.out.println(" Test status = " + status);
+        System.out.println(" Number of Tests Passed = " + result.getRunCount());
+        System.out.println(" Number of Tests Ignored = " + result.getIgnoreCount());
+        System.out.println(" Number of Tests Failed = " + result.getFailureCount());
+        System.out.println(" Time = " + result.getRunTime() / 1000.0 + "s");
     }
 }


### PR DESCRIPTION
Quick fix for the VSCode issue running tests Tuesday night (hopefully)

I think the issue was maven config not expecting the same project structure as NetNeans (i.e. `test/unit/test`, according to Google maven tests is normally expected in `src/test/java/test`), so adding the `testSourceDirectory` to `pom.xml` seems to bring the test dir into scope of the maven project. 

This allows the `Run Java`, and also gets ran during `mvn package`. However, there were compilation issues as the junit library was downloaded in the `Libraries` dir, but not added as dependency to maven (so some unknown imports resolved).

Also just added the other test boilerplate from the NetBeans project version.

